### PR TITLE
feat: setIsGracefulFailureMode(false) re-throws assignment exceptions

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -16,7 +16,8 @@ EppoClient::EppoClient(std::shared_ptr<ConfigurationStore> configStore,
     : configurationStore_(configStore),
       assignmentLogger_(assignmentLogger),
       banditLogger_(banditLogger),
-      applicationLogger_(applicationLogger ? applicationLogger : std::make_shared<NoOpApplicationLogger>()) {}
+      applicationLogger_(applicationLogger ? applicationLogger : std::make_shared<NoOpApplicationLogger>()),
+      isGracefulFailureMode_(true) {}
 
 bool EppoClient::getBoolAssignment(const std::string& flagKey,
                                    const std::string& subjectKey,
@@ -28,6 +29,9 @@ bool EppoClient::getBoolAssignment(const std::string& flagKey,
         return extractVariation(variation, flagKey, VariationType::BOOLEAN, defaultValue);
     } catch (const std::exception& e) {
         applicationLogger_->error(std::string("Error in getBoolAssignment: ") + e.what());
+        if (!isGracefulFailureMode_) {
+            throw;
+        }
         return defaultValue;
     }
 }
@@ -42,6 +46,9 @@ double EppoClient::getNumericAssignment(const std::string& flagKey,
         return extractVariation(variation, flagKey, VariationType::NUMERIC, defaultValue);
     } catch (const std::exception& e) {
         applicationLogger_->error(std::string("Error in getNumericAssignment: ") + e.what());
+        if (!isGracefulFailureMode_) {
+            throw;
+        }
         return defaultValue;
     }
 }
@@ -56,6 +63,9 @@ int64_t EppoClient::getIntegerAssignment(const std::string& flagKey,
         return extractVariation(variation, flagKey, VariationType::INTEGER, defaultValue);
     } catch (const std::exception& e) {
         applicationLogger_->error(std::string("Error in getIntegerAssignment: ") + e.what());
+        if (!isGracefulFailureMode_) {
+            throw;
+        }
         return defaultValue;
     }
 }
@@ -70,6 +80,9 @@ std::string EppoClient::getStringAssignment(const std::string& flagKey,
         return extractVariation(variation, flagKey, VariationType::STRING, defaultValue);
     } catch (const std::exception& e) {
         applicationLogger_->error(std::string("Error in getStringAssignment: ") + e.what());
+        if (!isGracefulFailureMode_) {
+            throw;
+        }
         return defaultValue;
     }
 }
@@ -84,6 +97,9 @@ nlohmann::json EppoClient::getJSONAssignment(const std::string& flagKey,
         return extractVariation(variation, flagKey, VariationType::JSON, defaultValue);
     } catch (const std::exception& e) {
         applicationLogger_->error(std::string("Error in getJSONAssignment: ") + e.what());
+        if (!isGracefulFailureMode_) {
+            throw;
+        }
         return defaultValue;
     }
 }
@@ -111,6 +127,9 @@ std::string EppoClient::getSerializedJSONAssignment(const std::string& flagKey,
         return std::get<nlohmann::json>(*variation).dump();
     } catch (const std::exception& e) {
         applicationLogger_->error(std::string("Error in getSerializedJSONAssignment: ") + e.what());
+        if (!isGracefulFailureMode_) {
+            throw;
+        }
         return defaultValue;
     }
 }
@@ -268,6 +287,10 @@ BanditResult EppoClient::getBanditActionInternal(const std::string& flagKey,
     logBanditAction(event);
 
     return BanditResult(variation, evaluation.actionKey);
+}
+
+void EppoClient::setIsGracefulFailureMode(bool isGracefulFailureMode) {
+    isGracefulFailureMode_ = isGracefulFailureMode;
 }
 
 } // namespace eppoclient

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -43,6 +43,7 @@ private:
     std::shared_ptr<AssignmentLogger> assignmentLogger_;
     std::shared_ptr<BanditLogger> banditLogger_;
     std::shared_ptr<ApplicationLogger> applicationLogger_;
+    bool isGracefulFailureMode_;
 
     // Internal method to get assignment value
     std::optional<std::variant<std::string, int64_t, double, bool, nlohmann::json>>
@@ -136,6 +137,9 @@ public:
                                 const ContextAttributes& subjectAttributes,
                                 const std::map<std::string, ContextAttributes>& actions,
                                 const std::string& defaultVariation);
+
+    // Set graceful failure mode
+    void setIsGracefulFailureMode(bool isGracefulFailureMode);
 
     // Get configuration store
     std::shared_ptr<ConfigurationStore> getConfigurationStore() const {

--- a/test/test_graceful_failure_mode.cpp
+++ b/test/test_graceful_failure_mode.cpp
@@ -1,0 +1,487 @@
+#include <catch_amalgamated.hpp>
+#include "../src/client.hpp"
+#include "../src/config_response.hpp"
+#include <nlohmann/json.hpp>
+#include <memory>
+
+using namespace eppoclient;
+using json = nlohmann::json;
+
+namespace {
+    // Mock logger to capture log messages for testing
+    class MockApplicationLogger : public ApplicationLogger {
+    public:
+        std::vector<std::string> debugMessages;
+        std::vector<std::string> infoMessages;
+        std::vector<std::string> warnMessages;
+        std::vector<std::string> errorMessages;
+
+        void debug(const std::string& message) override {
+            debugMessages.push_back(message);
+        }
+
+        void info(const std::string& message) override {
+            infoMessages.push_back(message);
+        }
+
+        void warn(const std::string& message) override {
+            warnMessages.push_back(message);
+        }
+
+        void error(const std::string& message) override {
+            errorMessages.push_back(message);
+        }
+
+        void clear() {
+            debugMessages.clear();
+            infoMessages.clear();
+            warnMessages.clear();
+            errorMessages.clear();
+        }
+    };
+} // anonymous namespace
+
+TEST_CASE("Graceful failure mode - Default behavior (graceful mode enabled)", "[graceful-failure]") {
+    // Create a configuration store with empty config (no flags)
+    auto configStore = std::make_shared<ConfigurationStore>();
+    Configuration emptyConfig(ConfigResponse{});
+    configStore->setConfiguration(emptyConfig);
+
+    auto mockLogger = std::make_shared<MockApplicationLogger>();
+
+    // Create client (graceful mode is enabled by default)
+    auto client = std::make_shared<EppoClient>(configStore, nullptr, nullptr, mockLogger);
+
+    Attributes attrs;
+    attrs["test"] = std::string("value");
+
+    SECTION("getBoolAssignment returns default value on empty subject key error") {
+        bool result = client->getBoolAssignment("test-flag", "", attrs, true);
+
+        // Should return default value
+        CHECK(result == true);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getBoolAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getNumericAssignment returns default value on empty subject key error") {
+        mockLogger->clear();
+        double result = client->getNumericAssignment("test-flag", "", attrs, 42.5);
+
+        // Should return default value
+        CHECK(result == 42.5);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getNumericAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getIntegerAssignment returns default value on empty flag key error") {
+        mockLogger->clear();
+        int64_t result = client->getIntegerAssignment("", "test-subject", attrs, 123);
+
+        // Should return default value
+        CHECK(result == 123);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getIntegerAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getStringAssignment returns default value on empty flag key error") {
+        mockLogger->clear();
+        std::string result = client->getStringAssignment("", "test-subject", attrs, "default");
+
+        // Should return default value
+        CHECK(result == "default");
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getStringAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getJSONAssignment returns default value on empty subject key error") {
+        mockLogger->clear();
+        json defaultJson = {{"key", "value"}};
+        json result = client->getJSONAssignment("test-flag", "", attrs, defaultJson);
+
+        // Should return default value
+        CHECK(result == defaultJson);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getJSONAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getSerializedJSONAssignment returns default value on empty subject key error") {
+        mockLogger->clear();
+        std::string defaultValue = R"({"default":"value"})";
+        std::string result = client->getSerializedJSONAssignment("test-flag", "", attrs, defaultValue);
+
+        // Should return default value
+        CHECK(result == defaultValue);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getSerializedJSONAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+}
+
+TEST_CASE("Graceful failure mode - Non-graceful mode (exceptions rethrown)", "[graceful-failure]") {
+    // Create a configuration store with empty config
+    auto configStore = std::make_shared<ConfigurationStore>();
+    Configuration emptyConfig(ConfigResponse{});
+    configStore->setConfiguration(emptyConfig);
+
+    auto mockLogger = std::make_shared<MockApplicationLogger>();
+
+    // Create client and disable graceful failure mode
+    auto client = std::make_shared<EppoClient>(configStore, nullptr, nullptr, mockLogger);
+    client->setIsGracefulFailureMode(false);
+
+    Attributes attrs;
+    attrs["test"] = std::string("value");
+
+    SECTION("getBoolAssignment rethrows exception after logging") {
+        REQUIRE_THROWS_AS(
+            client->getBoolAssignment("test-flag", "", attrs, true),
+            std::invalid_argument
+        );
+
+        // Should have logged error before rethrowing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getBoolAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getNumericAssignment rethrows exception after logging") {
+        mockLogger->clear();
+        REQUIRE_THROWS_AS(
+            client->getNumericAssignment("test-flag", "", attrs, 42.5),
+            std::invalid_argument
+        );
+
+        // Should have logged error before rethrowing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getNumericAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getIntegerAssignment rethrows exception after logging") {
+        mockLogger->clear();
+        REQUIRE_THROWS_AS(
+            client->getIntegerAssignment("", "test-subject", attrs, 123),
+            std::invalid_argument
+        );
+
+        // Should have logged error before rethrowing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getIntegerAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getStringAssignment rethrows exception after logging") {
+        mockLogger->clear();
+        REQUIRE_THROWS_AS(
+            client->getStringAssignment("", "test-subject", attrs, "default"),
+            std::invalid_argument
+        );
+
+        // Should have logged error before rethrowing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getStringAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getJSONAssignment rethrows exception after logging") {
+        mockLogger->clear();
+        json defaultJson = {{"key", "value"}};
+        REQUIRE_THROWS_AS(
+            client->getJSONAssignment("test-flag", "", attrs, defaultJson),
+            std::invalid_argument
+        );
+
+        // Should have logged error before rethrowing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getJSONAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+
+    SECTION("getSerializedJSONAssignment rethrows exception after logging") {
+        mockLogger->clear();
+        std::string defaultValue = R"({"default":"value"})";
+        REQUIRE_THROWS_AS(
+            client->getSerializedJSONAssignment("test-flag", "", attrs, defaultValue),
+            std::invalid_argument
+        );
+
+        // Should have logged error before rethrowing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("Error in getSerializedJSONAssignment") != std::string::npos) {
+                foundError = true;
+                break;
+            }
+        }
+        CHECK(foundError);
+    }
+}
+
+TEST_CASE("Graceful failure mode - Toggling behavior", "[graceful-failure]") {
+    // Create a configuration store with empty config
+    auto configStore = std::make_shared<ConfigurationStore>();
+    Configuration emptyConfig(ConfigResponse{});
+    configStore->setConfiguration(emptyConfig);
+
+    auto mockLogger = std::make_shared<MockApplicationLogger>();
+
+    auto client = std::make_shared<EppoClient>(configStore, nullptr, nullptr, mockLogger);
+
+    Attributes attrs;
+    attrs["test"] = std::string("value");
+
+    SECTION("Can toggle from graceful to non-graceful mode") {
+        // Start in graceful mode (default) - trigger error with empty subject key
+        bool result1 = client->getBoolAssignment("test-flag", "", attrs, false);
+        CHECK(result1 == false);  // Returns default
+
+        mockLogger->clear();
+
+        // Switch to non-graceful mode
+        client->setIsGracefulFailureMode(false);
+
+        // Now it should throw
+        REQUIRE_THROWS_AS(
+            client->getBoolAssignment("test-flag", "", attrs, false),
+            std::invalid_argument
+        );
+    }
+
+    SECTION("Can toggle from non-graceful to graceful mode") {
+        // Switch to non-graceful mode
+        client->setIsGracefulFailureMode(false);
+
+        // Should throw with empty subject key
+        REQUIRE_THROWS_AS(
+            client->getBoolAssignment("test-flag", "", attrs, false),
+            std::invalid_argument
+        );
+
+        mockLogger->clear();
+
+        // Switch back to graceful mode
+        client->setIsGracefulFailureMode(true);
+
+        // Should return default now
+        bool result = client->getBoolAssignment("test-flag", "", attrs, true);
+        CHECK(result == true);
+    }
+
+    SECTION("Can toggle multiple times") {
+        // Start graceful (default) - use empty subject key to trigger error
+        bool result1 = client->getBoolAssignment("test-flag", "", attrs, true);
+        CHECK(result1 == true);
+
+        // Toggle to non-graceful
+        client->setIsGracefulFailureMode(false);
+        REQUIRE_THROWS(client->getBoolAssignment("test-flag", "", attrs, true));
+
+        // Toggle back to graceful
+        client->setIsGracefulFailureMode(true);
+        bool result2 = client->getBoolAssignment("test-flag", "", attrs, false);
+        CHECK(result2 == false);
+
+        // Toggle to non-graceful again
+        client->setIsGracefulFailureMode(false);
+        REQUIRE_THROWS(client->getBoolAssignment("test-flag", "", attrs, true));
+    }
+}
+
+TEST_CASE("Graceful failure mode - Exception type preservation", "[graceful-failure]") {
+    // Test that bare throw preserves the original exception type (std::invalid_argument)
+    auto configStore = std::make_shared<ConfigurationStore>();
+    Configuration emptyConfig(ConfigResponse{});
+    configStore->setConfiguration(emptyConfig);
+
+    auto mockLogger = std::make_shared<MockApplicationLogger>();
+
+    auto client = std::make_shared<EppoClient>(configStore, nullptr, nullptr, mockLogger);
+    client->setIsGracefulFailureMode(false);
+
+    Attributes attrs;
+    attrs["test"] = std::string("value");
+
+    SECTION("Rethrown exception preserves original type (invalid_argument)") {
+        try {
+            // Empty subject key triggers std::invalid_argument
+            client->getBoolAssignment("test-flag", "", attrs, false);
+            FAIL("Should have thrown an exception");
+        } catch (const std::invalid_argument& e) {
+            // Successfully caught the specific exception type
+            CHECK(std::string(e.what()).find("no subject key provided") != std::string::npos);
+        } catch (const std::exception& e) {
+            FAIL("Exception was sliced - caught base type instead of derived type");
+        }
+    }
+}
+
+TEST_CASE("Graceful failure mode - Empty subject key errors", "[graceful-failure]") {
+    // Create a working configuration store with empty config
+    auto configStore = std::make_shared<ConfigurationStore>();
+    Configuration emptyConfig(ConfigResponse{});
+    configStore->setConfiguration(emptyConfig);
+
+    auto mockLogger = std::make_shared<MockApplicationLogger>();
+    auto client = std::make_shared<EppoClient>(configStore, nullptr, nullptr, mockLogger);
+
+    Attributes attrs;
+    attrs["test"] = std::string("value");
+
+    SECTION("Empty subject key in graceful mode returns default") {
+        bool result = client->getBoolAssignment("test-flag", "", attrs, true);
+        CHECK(result == true);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundSubjectKeyError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("No subject key provided") != std::string::npos ||
+                msg.find("no subject key provided") != std::string::npos) {
+                foundSubjectKeyError = true;
+                break;
+            }
+        }
+        CHECK(foundSubjectKeyError);
+    }
+
+    SECTION("Empty subject key in non-graceful mode throws") {
+        mockLogger->clear();
+        client->setIsGracefulFailureMode(false);
+
+        REQUIRE_THROWS_AS(
+            client->getBoolAssignment("test-flag", "", attrs, true),
+            std::invalid_argument
+        );
+
+        // Should have logged error before throwing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+    }
+}
+
+TEST_CASE("Graceful failure mode - Empty flag key errors", "[graceful-failure]") {
+    // Create a working configuration store with empty config
+    auto configStore = std::make_shared<ConfigurationStore>();
+    Configuration emptyConfig(ConfigResponse{});
+    configStore->setConfiguration(emptyConfig);
+
+    auto mockLogger = std::make_shared<MockApplicationLogger>();
+    auto client = std::make_shared<EppoClient>(configStore, nullptr, nullptr, mockLogger);
+
+    Attributes attrs;
+    attrs["test"] = std::string("value");
+
+    SECTION("Empty flag key in graceful mode returns default") {
+        bool result = client->getBoolAssignment("", "test-subject", attrs, false);
+        CHECK(result == false);
+
+        // Should have logged error
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+        bool foundFlagKeyError = false;
+        for (const auto& msg : mockLogger->errorMessages) {
+            if (msg.find("No flag key provided") != std::string::npos ||
+                msg.find("no flag key provided") != std::string::npos) {
+                foundFlagKeyError = true;
+                break;
+            }
+        }
+        CHECK(foundFlagKeyError);
+    }
+
+    SECTION("Empty flag key in non-graceful mode throws") {
+        mockLogger->clear();
+        client->setIsGracefulFailureMode(false);
+
+        REQUIRE_THROWS_AS(
+            client->getBoolAssignment("", "test-subject", attrs, false),
+            std::invalid_argument
+        );
+
+        // Should have logged error before throwing
+        REQUIRE(mockLogger->errorMessages.size() >= 1);
+    }
+}


### PR DESCRIPTION
  ## Summary

  This PR adds a new `setIsGracefulFailureMode(bool)` method to `EppoClient` that allows users to control exception handling behavior in assignment methods. By default, the client operates in graceful failure mode (existing behavior), but users can now opt into non-graceful mode where exceptions are rethrown after logging.

  ## Motivation

  Some users need stricter error handling in their applications where silent failures (returning default values) could mask critical issues. This change provides flexibility while maintaining backward compatibility with the existing graceful failure behavior.

  ## Changes

  ### API Changes

  **New Method:**
  ```cpp
  void EppoClient::setIsGracefulFailureMode(bool isGracefulFailureMode)

  Behavior:
  - When true (default): Catches exceptions, logs them, and returns default values (existing behavior)
  - When false: Catches exceptions, logs them, then rethrows using throw; to preserve exception type

  Affected Methods:
  - getBoolAssignment
  - getNumericAssignment
  - getIntegerAssignment
  - getStringAssignment
  - getJSONAssignment
  - getSerializedJSONAssignment

  Unaffected Methods:
  - logAssignment - Always handles errors gracefully
  - logBanditAction - Always handles errors gracefully

  Implementation Details

  1. Added isGracefulFailureMode_ member variable (defaults to true)
  2. Modified catch blocks in all assignment methods to check the flag
  3. Uses bare throw; to rethrow exceptions, preserving the original exception type without slicing
  4. Member variable is initialized in the constructor initializer list

  Example Usage

  // Default behavior - graceful failure mode
  auto client = std::make_shared<EppoClient>(configStore);
  bool value = client->getBoolAssignment("flag", "user", attrs, false);
  // Returns default value on error

  // Opt into non-graceful mode
  client->setIsGracefulFailureMode(false);
  try {
      bool value = client->getBoolAssignment("flag", "user", attrs, false);
  } catch (const std::exception& e) {
      // Exception is thrown after being logged
      handleError(e);
  }

  // Can toggle back at runtime
  client->setIsGracefulFailureMode(true);
```
  ## Testing

  #### Added comprehensive test suite in test/test_graceful_failure_mode.cpp:

  - ✅ Default graceful behavior - All assignment methods return defaults on errors
  - ✅ Non-graceful mode - All assignment methods rethrow after logging
  - ✅ Runtime toggling - Mode can be changed multiple times during execution
  - ✅ Exception type preservation - throw; correctly preserves derived exception types
  - ✅ Empty key validation - Both subject key and flag key validation errors handled correctly

  #### Test Results:
  - 55 assertions in 6 test cases, all passing
  - Full test suite: 1661 assertions in 88 test cases, all passing

  ## Backward Compatibility

  ✅ Fully backward compatible - The default behavior is unchanged. Existing code will continue to work exactly as before. Only users who explicitly call setIsGracefulFailureMode(false) will see different behavior.

  ## Notes

  - The implementation uses bare `throw;` rather than `throw e;` to avoid exception slicing and preserve the exact exception type
  - Error logging occurs in both modes before any exception is rethrown
  - The graceful failure mode setting can be changed at runtime, allowing dynamic behavior based on application state